### PR TITLE
Replaced tags with keywords in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "http://gulpjs.com",
   "repository": "gulpjs/gulp",
   "author": "Fractal <contact@wearefractal.com> (http://wearefractal.com/)",
-  "tags": [
+  "keywords": [
     "build",
     "stream",
     "system",


### PR DESCRIPTION
Hey there, I noticed that gulp's info on npmjs has no keywords. 

![npmjs](https://cloud.githubusercontent.com/assets/9853904/22471584/ca4a1358-e7a0-11e6-896c-1ac98ab53b2d.PNG)


Thought I'd do an easy fix for you by just switching out tags for keywords.

Hope you have a great day!

